### PR TITLE
dfxp: examine the contents of div tags for timing information (cbs)

### DIFF
--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -273,7 +273,7 @@ dfxp_get_duration(xmlDoc *doc)
 	unsigned node_stack_pos = 0;
 	int nodes_left = DFXP_DURATION_ESTIMATE_NODES;
 	int64_t result = 0;
-	int64_t cur;
+	dfxp_timestamp ts = {0};
 
 	for (cur_node = xmlDocGetRootElement(doc); ; cur_node = cur_node->prev)
 	{
@@ -294,6 +294,16 @@ dfxp_get_duration(xmlDoc *doc)
 			continue;
 		}
 
+		// timestamp information can be inside a div tag too
+		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_DIV) == 0)
+		{
+			dfxp_extract_time(cur_node, &ts);
+			if (ts.end_time > result)
+			{
+				result = ts.end_time;
+			}
+		}
+
 		// recurse into non-p nodes
 		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_P) != 0)
 		{
@@ -309,11 +319,11 @@ dfxp_get_duration(xmlDoc *doc)
 			continue;
 		}
 
-		// get the end time of this p node
-		cur = dfxp_get_end_time(cur_node);
-		if (cur > result)
+		// timestamp information can be inside a p tag
+		dfxp_extract_time(cur_node, &ts);
+		if (ts.end_time > result)
 		{
-			result = cur;
+			result = ts.end_time;
 		}
 
 		nodes_left--;

--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -704,13 +704,13 @@ dfxp_parse_frames(
 	uint64_t start;
 	uint64_t end;
 	int64_t last_start_time = 0;
-	int64_t start_time = 0;
-	int64_t end_time = 0;
-	int64_t duration;
+
+	dfxp_timestamp t = {0};
+
 	xmlNode* node_stack[DFXP_MAX_STACK_DEPTH];
 	xmlNode* cur_node;
+	xmlNode* last_div = NULL;
 	xmlNode temp_node;
-	xmlChar* attr;
 	unsigned node_stack_pos = 0;
 	vod_str_t text;
 	vod_status_t rc;
@@ -763,8 +763,8 @@ dfxp_parse_frames(
 			{
 				if (cur_frame != NULL)
 				{
-					cur_frame->duration = end_time - start_time;
-					track->total_frames_duration = end_time - track->first_frame_time_offset;
+					cur_frame->duration = t.end_time - t.start_time;
+					track->total_frames_duration = t.end_time - track->first_frame_time_offset;
 				}
 				break;
 			}
@@ -780,10 +780,15 @@ dfxp_parse_frames(
 
 		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_P) != 0)
 		{
-			if (cur_node->children == NULL ||
-				node_stack_pos >= vod_array_entries(node_stack))
+			if (cur_node->children == NULL || node_stack_pos >= vod_array_entries(node_stack))
 			{
 				continue;
+			}
+
+			// NOTE(as): It's a div, so save it in case the p-tag doesn't have the time inside 
+			if (vod_strcmp(cur_node->name, DFXP_ELEMENT_DIV) == 0)
+			{
+				last_div = cur_node;
 			}
 
 			node_stack[node_stack_pos++] = cur_node;
@@ -792,94 +797,29 @@ dfxp_parse_frames(
 			continue;
 		}
 
-		// handle p element
-		attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_END);
-		if (attr != NULL)
+		// handle p element or the last-visited div
+		if (!dfxp_extract_time(cur_node, &t))
 		{
-			// has end time
-			end_time = dfxp_parse_timestamp(attr);
-			if (end_time < 0)
-			{
-				continue;
-			}
-
-			if ((uint64_t)end_time < start)
-			{
-				track->first_frame_index++;
-				continue;
-			}
-
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_BEGIN);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			start_time = dfxp_parse_timestamp(attr);
-			if (start_time < 0)
+			if (last_div == NULL || !dfxp_extract_time(last_div, &t))
 			{
 				continue;
 			}
 		}
-		else
+
+		if ((uint64_t)t.end_time < start)
 		{
-			// no end time
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_DUR);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			duration = dfxp_parse_timestamp(attr);
-			if (duration < 0)
-			{
-				continue;
-			}
-
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_BEGIN);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			start_time = dfxp_parse_timestamp(attr);
-			if (start_time < 0)
-			{
-				continue;
-			}
-
-			end_time = start_time + duration;
-			if ((uint64_t)end_time < start)
-			{
 				track->first_frame_index++;
 				continue;
-			}
 		}
 
-		if (start_time >= end_time)
+		if (t.start_time >= t.end_time)
 		{
 			continue;
 		}
 
 		// apply clipping
-		if (start_time >= (int64_t)base_time)
-		{
-			start_time -= base_time;
-			if ((uint64_t)start_time > clip_to)
-			{
-				start_time = clip_to;
-			}
-		}
-		else
-		{
-			start_time = 0;
-		}
-
-		end_time -= base_time;
-		if ((uint64_t)end_time > clip_to)
-		{
-			end_time = clip_to;
-		}
+		t.start_time = dfxp_clamp(t.start_time - base_time, 0, clip_to);
+		t.end_time = dfxp_clamp(t.end_time - base_time, 0, clip_to);
 
 		// get the text
 		rc = dfxp_get_frame_body(
@@ -901,16 +841,16 @@ dfxp_parse_frames(
 		// adjust the duration of the previous frame
 		if (cur_frame != NULL)
 		{
-			cur_frame->duration = start_time - last_start_time;
+			cur_frame->duration = t.start_time - last_start_time;
 		}
 		else
 		{
-			track->first_frame_time_offset = start_time;
+			track->first_frame_time_offset = t.start_time;
 		}
 
-		if ((uint64_t)start_time >= end)
+		if ((uint64_t)t.start_time >= end)
 		{
-			track->total_frames_duration = start_time - track->first_frame_time_offset;
+			track->total_frames_duration = t.start_time - track->first_frame_time_offset;
 			break;
 		}
 
@@ -925,11 +865,11 @@ dfxp_parse_frames(
 
 		cur_frame->offset = (uintptr_t)text.data;
 		cur_frame->size = text.len;
-		cur_frame->pts_delay = end_time - start_time;
+		cur_frame->pts_delay = t.end_time - t.start_time;
 		cur_frame->key_frame = 0;
 		track->total_frames_size += cur_frame->size;
 
-		last_start_time = start_time;
+		last_start_time = t.start_time;
 	}
 
 	track->frame_count = frames.nelts;

--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -17,6 +17,7 @@
 #define DFXP_ELEMENT_P (u_char*)"p"
 #define DFXP_ELEMENT_BR (u_char*)"br"
 #define DFXP_ELEMENT_SPAN (u_char*)"span"
+#define DFXP_ELEMENT_DIV (u_char*)"div"
 
 #define DFXP_ATTR_BEGIN (u_char*)"begin"
 #define DFXP_ATTR_END (u_char*)"end"
@@ -223,46 +224,42 @@ dfxp_parse_timestamp(u_char* ts)
 	return -1;
 }
 
-static int64_t 
-dfxp_get_end_time(xmlNode *cur_node)
+typedef struct{
+	int64_t start_time;
+	int64_t end_time;
+	int64_t duration;
+} dfxp_timestamp;
+
+int64_t
+dfxp_parse_timestamp0(xmlNode *node, xmlChar *name, int64_t *ts)
 {
-	xmlChar* attr;
-	int64_t begin;
-	int64_t dur;
-	
-	// prefer the end attribute
-	attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_END);
-	if (attr != NULL)
-	{
-		return dfxp_parse_timestamp(attr);
-	}
-	
-	// fall back to dur + start
-	attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_DUR);
-	if (attr == NULL)
-	{
-		return -1;
-	}
-	
-	dur = dfxp_parse_timestamp(attr);
-	if (dur < 0)
-	{
-		return -1;
-	}
-	
-	attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_BEGIN);
-	if (attr == NULL)
-	{
-		return -1;
-	}
-	
-	begin = dfxp_parse_timestamp(attr);
-	if (begin < 0)
-	{
-		return -1;
-	}
-	
-	return begin + dur;
+	*ts = -1;
+	xmlChar* attr = dfxp_get_xml_prop(node, name);
+	if (attr == NULL) return -1;
+	*ts =  dfxp_parse_timestamp(attr);
+	return *ts;
+}
+
+int
+dfxp_extract_time(xmlNode *node, dfxp_timestamp *t)
+{
+	dfxp_parse_timestamp0(node, DFXP_ATTR_BEGIN, &t->start_time);
+	dfxp_parse_timestamp0(node, DFXP_ATTR_END, &t->end_time);
+	dfxp_parse_timestamp0(node, DFXP_ATTR_DUR, &t->duration);
+
+	if (t->start_time < 0) return 0;
+	if (t->end_time < 0) t->end_time = t->start_time+t->duration;
+	if (t->duration < 0) t->duration = t->end_time-t->start_time;
+
+	return 1;
+}
+
+int64_t
+dfxp_clamp(int64_t v, int64_t lo, int64_t hi)
+{
+	if (v < lo)  return lo;
+	if (v > hi)  return hi;
+	return v;
 }
 
 static uint64_t

--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -271,7 +271,7 @@ dfxp_get_duration(xmlDoc *doc)
 	unsigned node_stack_pos = 0;
 	int nodes_left = DFXP_DURATION_ESTIMATE_NODES;
 	int64_t result = 0;
-	int64_t cur;
+	dfxp_timestamp ts = {0};
 
 	for (cur_node = xmlDocGetRootElement(doc); ; cur_node = cur_node->prev)
 	{
@@ -292,6 +292,16 @@ dfxp_get_duration(xmlDoc *doc)
 			continue;
 		}
 
+		// timestamp information can be inside a div tag too
+		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_DIV) == 0)
+		{
+			dfxp_extract_time(cur_node, &ts);
+			if (ts.end_time > result)
+			{
+				result = ts.end_time;
+			}
+		}
+
 		// recurse into non-p nodes
 		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_P) != 0)
 		{
@@ -307,11 +317,11 @@ dfxp_get_duration(xmlDoc *doc)
 			continue;
 		}
 
-		// get the end time of this p node
-		cur = dfxp_get_end_time(cur_node);
-		if (cur > result)
+		// timestamp information can be inside a p tag
+		dfxp_extract_time(cur_node, &ts);
+		if (ts.end_time > result)
 		{
-			result = cur;
+			result = ts.end_time;
 		}
 
 		nodes_left--;

--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -702,13 +702,13 @@ dfxp_parse_frames(
 	uint64_t start;
 	uint64_t end;
 	int64_t last_start_time = 0;
-	int64_t start_time = 0;
-	int64_t end_time = 0;
-	int64_t duration;
+
+	dfxp_timestamp t = {0};
+
 	xmlNode* node_stack[DFXP_MAX_STACK_DEPTH];
 	xmlNode* cur_node;
+	xmlNode* last_div = NULL;
 	xmlNode temp_node;
-	xmlChar* attr;
 	unsigned node_stack_pos = 0;
 	vod_str_t text;
 	vod_status_t rc;
@@ -761,8 +761,8 @@ dfxp_parse_frames(
 			{
 				if (cur_frame != NULL)
 				{
-					cur_frame->duration = end_time - start_time;
-					track->total_frames_duration = end_time - track->first_frame_time_offset;
+					cur_frame->duration = t.end_time - t.start_time;
+					track->total_frames_duration = t.end_time - track->first_frame_time_offset;
 				}
 				break;
 			}
@@ -778,10 +778,15 @@ dfxp_parse_frames(
 
 		if (vod_strcmp(cur_node->name, DFXP_ELEMENT_P) != 0)
 		{
-			if (cur_node->children == NULL ||
-				node_stack_pos >= vod_array_entries(node_stack))
+			if (cur_node->children == NULL || node_stack_pos >= vod_array_entries(node_stack))
 			{
 				continue;
+			}
+
+			// NOTE(as): It's a div, so save it in case the p-tag doesn't have the time inside 
+			if (vod_strcmp(cur_node->name, DFXP_ELEMENT_DIV) == 0)
+			{
+				last_div = cur_node;
 			}
 
 			node_stack[node_stack_pos++] = cur_node;
@@ -790,94 +795,29 @@ dfxp_parse_frames(
 			continue;
 		}
 
-		// handle p element
-		attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_END);
-		if (attr != NULL)
+		// handle p element or the last-visited div
+		if (!dfxp_extract_time(cur_node, &t))
 		{
-			// has end time
-			end_time = dfxp_parse_timestamp(attr);
-			if (end_time < 0)
-			{
-				continue;
-			}
-
-			if ((uint64_t)end_time < start)
-			{
-				track->first_frame_index++;
-				continue;
-			}
-
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_BEGIN);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			start_time = dfxp_parse_timestamp(attr);
-			if (start_time < 0)
+			if (last_div == NULL || !dfxp_extract_time(last_div, &t))
 			{
 				continue;
 			}
 		}
-		else
+
+		if ((uint64_t)t.end_time < start)
 		{
-			// no end time
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_DUR);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			duration = dfxp_parse_timestamp(attr);
-			if (duration < 0)
-			{
-				continue;
-			}
-
-			attr = dfxp_get_xml_prop(cur_node, DFXP_ATTR_BEGIN);
-			if (attr == NULL)
-			{
-				continue;
-			}
-
-			start_time = dfxp_parse_timestamp(attr);
-			if (start_time < 0)
-			{
-				continue;
-			}
-
-			end_time = start_time + duration;
-			if ((uint64_t)end_time < start)
-			{
 				track->first_frame_index++;
 				continue;
-			}
 		}
 
-		if (start_time >= end_time)
+		if (t.start_time >= t.end_time)
 		{
 			continue;
 		}
 
 		// apply clipping
-		if (start_time >= (int64_t)base_time)
-		{
-			start_time -= base_time;
-			if ((uint64_t)start_time > clip_to)
-			{
-				start_time = clip_to;
-			}
-		}
-		else
-		{
-			start_time = 0;
-		}
-
-		end_time -= base_time;
-		if ((uint64_t)end_time > clip_to)
-		{
-			end_time = clip_to;
-		}
+		t.start_time = dfxp_clamp(t.start_time - base_time, 0, clip_to);
+		t.end_time = dfxp_clamp(t.end_time - base_time, 0, clip_to);
 
 		// get the text
 		rc = dfxp_get_frame_body(
@@ -899,16 +839,16 @@ dfxp_parse_frames(
 		// adjust the duration of the previous frame
 		if (cur_frame != NULL)
 		{
-			cur_frame->duration = start_time - last_start_time;
+			cur_frame->duration = t.start_time - last_start_time;
 		}
 		else
 		{
-			track->first_frame_time_offset = start_time;
+			track->first_frame_time_offset = t.start_time;
 		}
 
-		if ((uint64_t)start_time >= end)
+		if ((uint64_t)t.start_time >= end)
 		{
-			track->total_frames_duration = start_time - track->first_frame_time_offset;
+			track->total_frames_duration = t.start_time - track->first_frame_time_offset;
 			break;
 		}
 
@@ -923,11 +863,11 @@ dfxp_parse_frames(
 
 		cur_frame->offset = (uintptr_t)text.data;
 		cur_frame->size = text.len;
-		cur_frame->pts_delay = end_time - start_time;
+		cur_frame->pts_delay = t.end_time - t.start_time;
 		cur_frame->key_frame = 0;
 		track->total_frames_size += cur_frame->size;
 
-		last_start_time = start_time;
+		last_start_time = t.start_time;
 	}
 
 	track->frame_count = frames.nelts;


### PR DESCRIPTION
---
Original Pull Request: https://github.com/kaltura/nginx-vod-module/pull/1136#issue-417622541

The current dfxp parser does not examine the contents of <div tags for timing information. This causes it to generate an empty manifest for some valid dfxp files. It is valid to have timing information in the <div, and I can provide more details and examples on request, but here are two files:

FILE A: http://flv.io/ABC142908_id.dfxp.xml
FILE B: http://flv.io/ABC142908_en-US.dfxp.xml
FILE B currently generates an empty manifest. This change fixes this.

I have made changes to two functions that examine timing information:

dfxp_get_duration, which traverses the entire XML to compute the ultimate duration of the subtitle's content.
dfxp_parse_frames, which traverses the XML in a similar fashion. It now looks at <p tags and reverts to the last-visited <div if there exists no timing information in the <p tag.
Additionally, there is set of helper functions to remove duplicate code, as reconciling my changes to work inline resulted in cruft. The resulting changes allow FILE B to be parsed, as well as combinations of FILE A and FILE B.

Additional Feedback: https://github.com/kaltura/nginx-vod-module/pull/1136#issuecomment-628847433

---

We have a few things to do in this branch based on the external PR feedback, but I believe they are not business-critical. Let's review this internally and merge it into our copy of the repo, and create another task to handle the changes suggested by the reviewer.

> Style

Good to have to get the PR merged and keep the code consistent, but not necessary for things to work. 

>Efficiency: 

These are nits, the routines do most of their work looking for timecodes in irrelevant places, for example, parsing head. We will not get much value out of these optimizations, because benchmarks on the corpus of our subtitle files before and after the patch have similar runtimes.

> Bug: last_div is not reset when walking up in the tree - meaning - it may fall back to using a div that is not an ancestor of the current p element.

I'm glad the reviewer pointed this out. I think the only time this could happen is if the user submits a file that isn't going to work anyway:

```
<div>
    <div timecode> <p text /> </div>
    <p text /> // uses timecode, even though its not a child, but there would have to be no <div, and no timecode in the p-tag
</div>
```

It could be nice to fix, but it's an edge-case, so I recommend a separate, lower-priority task for these modifications.

